### PR TITLE
Add note about having to hire a Kerbal before being able to change its suit to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SuitSwitcherForAll
 
-Enables WildBlueCore functionality to switch kerbals suits mid-flight for all crewed parts.
+Enables WildBlueCore functionality to switch kerbals suits mid-flight for all crewed parts. A Kerbal must be hired before their suit can be changed.
 
 
 Forum link: 


### PR DESCRIPTION
Comparison between a hired and unhired Kerbal:
![image](https://github.com/user-attachments/assets/088bd1fa-9524-4e1b-bc3b-ecb9cd231dbf)

Usually this isn't a problem, but if you launch a vessel without having hired the Kerbal (which can be done through RP-1's simulation feature), then the Kerbal's suit can not be changed. Pretty sure this is a stock KSP limitation.